### PR TITLE
Add wayland support

### DIFF
--- a/net.sourceforge.GrandOrgue.yml
+++ b/net.sourceforge.GrandOrgue.yml
@@ -9,7 +9,8 @@ rename-icon: GrandOrgue
 finish-args:
   # Needed for X11
   - --share=ipc
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   # Needed for note playpack
   - --socket=pulseaudio
   # Needed for PortAudio/MIDI


### PR DESCRIPTION
This is a simple modification to the flatpak manifest to enable the `wayland` display protocol as well as `x11`, for newer linux distributions. 

The `x11` permission has been replaced with `fallback-x11` to make the app use wayland by default if available, `x11` otherwise, as suggested by the official [documentation](https://docs.flatpak.org/en/latest/sandbox-permissions.html#standard-permissions).

This is useful for wayland desktops with fractional scaling, where using x11 makes the app window quite blurry.

﻿
