### PR TITLE
Disable PR automerge, since it's no longer allowed.

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "automerge-flathubbot-prs": true
-}


### PR DESCRIPTION
Disable PR automerge, according to https://docs.flathub.org/docs/for-app-authors/linter/#flathub-json-automerge-enabled.